### PR TITLE
Fixes multiple rewards padding / icon issues

### DIFF
--- a/templates/wowhead/quest.tpl
+++ b/templates/wowhead/quest.tpl
@@ -368,7 +368,7 @@
 						<table class="icontab">
 						<tr>
 {section name=j loop=$quest.itemchoices}
-								<th id="icontab-icon{$smarty.section.j.index+1}"></th>
+								<th id="icontab-icon{$smarty.section.j.index}"></th>
 								<td>
 									<span class="q{$quest.itemchoices[j].quality}">
 										<a href="?item={$quest.itemchoices[j].entry}">
@@ -381,7 +381,7 @@
 						</table>
 						<script type="text/javascript">
 						{section name=j loop=$quest.itemchoices}
-							ge('icontab-icon{$smarty.section.j.index+1}').appendChild(g_items.createIcon({$quest.itemchoices[j].entry}, 1, {$quest.itemchoices[j].count}));
+							ge('icontab-icon{$smarty.section.j.index}').appendChild(g_items.createIcon({$quest.itemchoices[j].entry}, 1, {$quest.itemchoices[j].count}));
 						{/section}
 						</script>
 {/if}
@@ -393,7 +393,7 @@
 						<table class="icontab">
 						<tr>{strip}
 {section name=j loop=$quest.itemrewards}
-								<th id="icontab-icon{$smarty.section.j.index+1}"></th>
+								<th id="icontab-icon{$smarty.section.j.index+4}"></th>
 								<td>
 									<span class="q{$quest.itemrewards[j].quality}">
 										<a href="?item={$quest.itemrewards[j].entry}">
@@ -406,7 +406,7 @@
 						</table>
 						<script type="text/javascript">
 						{section name=j loop=$quest.itemrewards}
-							ge('icontab-icon{$smarty.section.j.index+1}').appendChild(g_items.createIcon({$quest.itemrewards[j].entry}, 1, {$quest.itemrewards[j].count}));
+							ge('icontab-icon{$smarty.section.j.index+4}').appendChild(g_items.createIcon({$quest.itemrewards[j].entry}, 1, {$quest.itemrewards[j].count}));
 						{/section}
 						</script>
 {/if}


### PR DESCRIPTION
In regards to #13 

Before:
![screen shot 2018-07-10 at 22 10 49](https://user-images.githubusercontent.com/18648426/42709074-82ed8500-86df-11e8-918f-cfa5b182a824.png)

After:
![screen shot 2018-07-10 at 22 11 08](https://user-images.githubusercontent.com/18648426/42709080-8d245e5e-86df-11e8-97a4-858468e1f0a8.png)

I checked a few quests with pick one reward > 4 and you will also receive 1-2 items, appears to be working but not sure if this breaks things somewhere else!

Sorry for double PRs, redid my fork cause well, it got cluttered with my history